### PR TITLE
change cleaning of video's name

### DIFF
--- a/download_playlist.py
+++ b/download_playlist.py
@@ -14,8 +14,12 @@ def clean_title(video) -> str:
         opening_parenthesis_index = title.index("(")
         closing_parenthesis_index = title.index(")")
         title = title[:opening_parenthesis_index] + title[closing_parenthesis_index+1:]
-    if " - " not in title:  # add uploader if no author in initial title
-        title = video["uploader"] + " - " + title
+    if " - " not in title:  # add an 'artist' if no author in initial title
+        if len(video["artist"]) > 0:
+            title = video["artist"] + " - " + title
+        else:
+            title = video["channel"] + " - " + title # if it's youtube that automatically add 
+            # video then the "uploader" countains "[...] - Topic" so we try to use "channel"
     return title
 
 


### PR DESCRIPTION
Sometimes Youtube automatically creates videos of songs and albums, and then the _"uploader"_ value has a "_- Topic"_ at the end of its string, but Youtube usually fills in the _"artist"_ value. 
On the other hand, a user can upload a song/music from another artist, and in this case, if they do things right, they fill in the value of _"artist"_.
Hence the proposed modification.